### PR TITLE
Relax dependency on Node to allow newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/benkroeger/oniyi-ltpa#readme",
   "engines": {
-    "node": "^8.11.1"
+    "node": ">=8.11.1"
   },
   "files": [
     "lib/"


### PR DESCRIPTION
Hi @benkroeger ,

thanks for this great package! Would you consider relaxing the strict dependency on Node v8.x? We're using it without problems in Node v16, but receive the following warning during `npm install`:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'oniyi-ltpa@2.0.4',
npm WARN EBADENGINE   required: { node: '^8.11.1' },
npm WARN EBADENGINE   current: { node: 'v16.13.2', npm: '8.1.2' }
npm WARN EBADENGINE }
````

PR is attached. Thanks a lot!